### PR TITLE
Support multiple dst token mapping to a single src token on the same or different dst chain id

### DIFF
--- a/demo/onlyswap-e2e-demo.ts
+++ b/demo/onlyswap-e2e-demo.ts
@@ -50,6 +50,7 @@ async function main() {
 
     const { tx, amount } = await executeSwap(
       ERC20Src,
+      ERC20Dst,
       RouterSrc,
       recipientAddr,
       DST_CHAIN_ID,
@@ -70,7 +71,8 @@ async function main() {
     const formattedSwapRequestParams = {
       sender: swapRequestParams.sender,
       recipient: swapRequestParams.recipient,
-      token: swapRequestParams.token,
+      tokenIn: swapRequestParams.tokenIn,
+      tokenOut: swapRequestParams.tokenOut,
       amount: formatEther(swapRequestParams.amount),
       srcChainId: swapRequestParams.srcChainId,
       dstChainId: swapRequestParams.dstChainId,

--- a/demo/utilities/swap.ts
+++ b/demo/utilities/swap.ts
@@ -1,8 +1,9 @@
-import { formatEther, parseEther } from "ethers";
+import { parseEther } from "ethers";
 import { ERC20Token, Router } from "../../typechain-types";
 
 export async function executeSwap(
   ERC20Src: ERC20Token,
+  ERC20Dst: ERC20Token,
   RouterSrc: Router,
   recipient: string,
   DST_CHAIN_ID: number,
@@ -18,6 +19,7 @@ export async function executeSwap(
 
   const tx = await RouterSrc.requestCrossChainSwap(
     await ERC20Src.getAddress(),
+    await ERC20Dst.getAddress(),
     amount,
     fee,
     DST_CHAIN_ID,

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -9,7 +9,8 @@ interface IRouter {
     struct SwapRequestParameters {
         address sender; // Address initiating the swap on the source chain
         address recipient; // Address to receive tokens on the destination chain
-        address token; // Token address being transferred
+        address tokenIn; // Token address on the source chain
+        address tokenOut; // Token address on the destination chain
         uint256 amount; // Amount to be received by the recipient on the destination chain
         uint256 srcChainId; // Source chain ID where the request originated
         uint256 dstChainId; // Destination chain ID where tokens will be delivered
@@ -38,45 +39,13 @@ interface IRouter {
     /// @param requestId Hash of the transfer parameters
     /// @param srcChainId The source chain ID from which the request originated
     /// @param dstChainId The destination chain ID where the tokens will be delivered
-    /// @param token The address of the token being transferred
-    /// @param sender The address initiating the swap
-    /// @param recipient The address that will receive the tokens on the destination chain
-    /// @param amount The amount of tokens requested for transfer
-    /// @param fee The fee associated with the swap request
-    /// @param nonce A unique identifier to prevent replay attacks
-    /// @param requestedAt The timestamp when the swap request was created
-    event SwapRequested(
-        bytes32 indexed requestId,
-        uint256 indexed srcChainId,
-        uint256 indexed dstChainId,
-        address token,
-        address sender,
-        address recipient,
-        uint256 amount,
-        uint256 fee,
-        uint256 nonce,
-        uint256 requestedAt
-    );
+    event SwapRequested(bytes32 indexed requestId, uint256 indexed srcChainId, uint256 indexed dstChainId);
 
     /// @notice Emitted when a swap request is fulfilled on the destination chain by a solver
     /// @param requestId The unique ID of the swap request
     /// @param srcChainId The source chain ID from which the request originated
     /// @param dstChainId The destination chain ID where the tokens were delivered
-    /// @param token The address of the token that was transferred
-    /// @param solver The address that fulfilled the transfer
-    /// @param recipient The address that received the tokens on the destination chain
-    /// @param amount The amount transferred to the recipient
-    /// @param fulfilledAt The timestamp when the transfer was fulfilled
-    event SwapRequestFulfilled(
-        bytes32 indexed requestId,
-        uint256 indexed srcChainId,
-        uint256 indexed dstChainId,
-        address token,
-        address solver,
-        address recipient,
-        uint256 amount,
-        uint256 fulfilledAt
-    );
+    event SwapRequestFulfilled(bytes32 indexed requestId, uint256 indexed srcChainId, uint256 indexed dstChainId);
 
     /// @notice Emitted when a message is successfully fulfilled by a solver
     /// @param requestId Hash of the transfer parameters
@@ -106,7 +75,9 @@ interface IRouter {
     /// @param dstChainId The destination chain id
     /// @param dstToken The destination token address
     /// @param srcToken The source token address
-    event TokenMappingUpdated(uint256 dstChainId, address dstToken, address srcToken);
+    event TokenMappingAdded(uint256 dstChainId, address dstToken, address srcToken);
+
+    event TokenMappingRemoved(uint256 dstChainId, address dstToken, address srcToken);
 
     /// @notice Emitted when swap fees have been withdrawn to a recipient address
     /// @param token The token address of the withdrawn fees
@@ -116,16 +87,22 @@ interface IRouter {
 
     // -------- Core Transfer Logic --------
 
-    /// @notice Initiates a cross-chain swap request
-    /// @param token The address of the token to be swapped
-    /// @param amount The amount of tokens to be swapped
-    /// @param fee The fee associated with the swap request
-    /// @param dstChainId The destination chain ID where the tokens will be sent
-    /// @param recipient The address that will receive the tokens on the destination chain
-    /// @return requestId The unique ID of the created swap request
-    function requestCrossChainSwap(address token, uint256 amount, uint256 fee, uint256 dstChainId, address recipient)
-        external
-        returns (bytes32 requestId);
+    /// @notice Initiates a swap request
+    /// @param tokenIn Address of the input token on the source chain
+    /// @param tokenOut Address of the output token on the destination chain
+    /// @param amount Amount of tokens to swap
+    /// @param fee Total fee amount (in token units) to be paid by the user
+    /// @param dstChainId Target chain ID
+    /// @param recipient Address to receive swaped tokens on target chain
+    /// @return requestId The unique swap request id
+    function requestCrossChainSwap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amount,
+        uint256 fee,
+        uint256 dstChainId,
+        address recipient
+    ) external returns (bytes32 requestId);
 
     /// @notice Updates the fee for an unfulfilled swap request
     /// @param requestId The unique ID of the swap request to update
@@ -159,7 +136,7 @@ interface IRouter {
     /// @notice Generates a unique request ID based on the provided swap request parameters
     /// @param p The swap request parameters
     /// @return The generated request ID
-    function getRequestId(SwapRequestParameters memory p) external view returns (bytes32);
+    function getSwapRequestId(SwapRequestParameters memory p) external view returns (bytes32);
 
     /// @notice Retrieves the current chain ID
     /// @return The current chain ID
@@ -187,7 +164,7 @@ interface IRouter {
     /// @param srcToken The address of the source token
     /// @param dstChainId The destination chain ID
     /// @return The address of the mapped destination token
-    function getTokenMapping(address srcToken, uint256 dstChainId) external view returns (address);
+    function getTokenMapping(address srcToken, uint256 dstChainId) external view returns (address[] memory);
 
     /// @notice Retrieves the swap request parameters for a given request ID
     /// @param requestId The unique ID of the swap request
@@ -220,8 +197,7 @@ interface IRouter {
     /// @return solver The address of the solver who fulfilled the transfer
     /// @return recipient The address that received the tokens on the destination chain
     /// @return amount The amount of tokens transferred to the recipient
-    /// @return fulfilledAt The timestamp when the transfer was fulfilled
-    function getReceipt(bytes32 _requestId)
+    function getSwapRequestReceipt(bytes32 _requestId)
         external
         view
         returns (
@@ -232,12 +208,19 @@ interface IRouter {
             bool fulfilled,
             address solver,
             address recipient,
-            uint256 amount,
-            uint256 fulfilledAt
+            uint256 amount
         );
 
+    /// @notice Checks if a destination token is mapped for a given source token and destination chain ID
+    /// @param srcToken The address of the source token
+    /// @param dstChainId The destination chain ID
+    /// @param dstToken The address of the destination token
+    /// @return True if the destination token is mapped, false otherwise
+    function isDstTokenMapped(address srcToken, uint256 dstChainId, address dstToken) external view returns (bool);
+
     /// @notice Builds swap request parameters based on the provided details
-    /// @param token The address of the token to be swapped
+    /// @param tokenIn The address of the input token on the source chain
+    /// @param tokenOut The address of the output token on the destination chain
     /// @param amount The amount of tokens to be swapped
     /// @param verificationFeeAmount The verification fee amount
     /// @param solverFeeAmount The solver fee amount
@@ -246,7 +229,8 @@ interface IRouter {
     /// @param nonce A unique nonce for the request
     /// @return swapRequestParams A SwapRequestParameters struct containing the transfer parameters.
     function buildSwapRequestParameters(
-        address token,
+        address tokenIn,
+        address tokenOut,
         uint256 amount,
         uint256 verificationFeeAmount,
         uint256 solverFeeAmount,
@@ -288,6 +272,12 @@ interface IRouter {
     /// @param dstToken The address of the destination token
     /// @param srcToken The address of the source token
     function setTokenMapping(uint256 dstChainId, address dstToken, address srcToken) external;
+
+    /// @notice Removes the token mapping for a specific destination chain
+    /// @param dstChainId The destination chain ID
+    /// @param dstToken The address of the destination token
+    /// @param srcToken The address of the source token
+    function removeTokenMapping(uint256 dstChainId, address dstToken, address srcToken) external;
 
     /// @notice Withdraws verification fees to a specified address
     /// @param token The token address of the withdrawn fees

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -40,21 +40,13 @@ interface IRouter {
     /// @param requestId Hash of the transfer parameters
     /// @param srcChainId The source chain ID from which the request originated
     /// @param dstChainId The destination chain ID where the tokens will be delivered
-    event SwapRequested(
-        bytes32 indexed requestId,
-        uint256 indexed srcChainId,
-        uint256 indexed dstChainId
-    );
+    event SwapRequested(bytes32 indexed requestId, uint256 indexed srcChainId, uint256 indexed dstChainId);
 
     /// @notice Emitted when a swap request is fulfilled on the destination chain by a solver
     /// @param requestId The unique ID of the swap request
     /// @param srcChainId The source chain ID from which the request originated
     /// @param dstChainId The destination chain ID where the tokens were delivered
-    event SwapRequestFulfilled(
-        bytes32 indexed requestId,
-        uint256 indexed srcChainId,
-        uint256 indexed dstChainId
-    );
+    event SwapRequestFulfilled(bytes32 indexed requestId, uint256 indexed srcChainId, uint256 indexed dstChainId);
 
     /// @notice Emitted when a message is successfully fulfilled by a solver
     /// @param requestId Hash of the transfer parameters

--- a/src/libraries/ErrorsLib.sol
+++ b/src/libraries/ErrorsLib.sol
@@ -7,6 +7,7 @@ library ErrorsLib {
     error InvalidTokenOrRecipient();
     error ZeroAmount();
     error FeeTooLow();
+    error TokenMappingAlreadyExists();
     error TokenNotSupported();
     error UnauthorisedCaller();
     error NewFeeTooLow(uint256 newFee, uint256 currentFee);

--- a/test/hardhat/Router.test.ts
+++ b/test/hardhat/Router.test.ts
@@ -19,6 +19,7 @@ import {
   Result,
   keccak256,
   toUtf8Bytes,
+  ZeroAddress,
 } from "ethers";
 import { ethers } from "hardhat";
 
@@ -66,6 +67,52 @@ describe("Router", function () {
     await router.connect(owner).setTokenMapping(DST_CHAIN_ID, await dstToken.getAddress(), await srcToken.getAddress());
   });
 
+  it("should remove the token mapping for a specific destination chain", async () => {
+    // Ensure the token mapping exists before removal
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), DST_CHAIN_ID, await dstToken.getAddress())).to.be.true;
+
+    // Remove the token mapping
+    await router.connect(owner).removeTokenMapping(DST_CHAIN_ID, await dstToken.getAddress(), await srcToken.getAddress());
+
+    // Check that the token mapping has been removed
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), DST_CHAIN_ID, await dstToken.getAddress())).to.be.false;
+  });
+
+  it("should return false for isDstTokenMapped if the token mapping does not exist", async () => {
+    const nonExistentDstToken = ZeroAddress;
+
+    // Check that the token mapping does not exist
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), DST_CHAIN_ID, nonExistentDstToken)).to.be.false;
+  });
+
+  it("should map two token addresses to a src token on a single dst chain id", async () => {
+    const secondDstToken = await new ERC20Token__factory(owner).deploy("RUSD2", "RUSD2", 18);
+    
+    // First destination token already mapped in beforeEach
+    await expect(router.connect(owner).setTokenMapping(DST_CHAIN_ID, await dstToken.getAddress(), await srcToken.getAddress())).to.be.revertedWithCustomError(router, "TokenMappingAlreadyExists");
+
+    // Map second destination token
+    await router.connect(owner).setTokenMapping(DST_CHAIN_ID, await secondDstToken.getAddress(), await srcToken.getAddress());
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), DST_CHAIN_ID, await secondDstToken.getAddress())).to.be.true;
+  });
+
+  it("should map two tokens on different dst chain ids to a single src token", async () => {
+    const thirdDstToken = await new ERC20Token__factory(owner).deploy("RUSD3", "RUSD3", 18);
+    const fourthDstToken = await new ERC20Token__factory(owner).deploy("RUSD4", "RUSD4", 18);
+    const secondDstChainId = DST_CHAIN_ID + 1;
+
+    // Support the second destination chain ID
+    await router.connect(owner).permitDestinationChainId(secondDstChainId);
+
+    // Map first destination token
+    await router.connect(owner).setTokenMapping(DST_CHAIN_ID, await thirdDstToken.getAddress(), await srcToken.getAddress());
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), DST_CHAIN_ID, await thirdDstToken.getAddress())).to.be.true;
+
+    // Map second destination token on a different chain ID
+    await router.connect(owner).setTokenMapping(secondDstChainId, await fourthDstToken.getAddress(), await srcToken.getAddress());
+    expect(await router.isDstTokenMapped(await srcToken.getAddress(), secondDstChainId, await fourthDstToken.getAddress())).to.be.true;
+  });
+
   it("should initiate a swap request and emit message", async () => {
     const amount = parseEther("10");
     const fee = parseEther("1");
@@ -75,7 +122,7 @@ describe("Router", function () {
     await srcToken.connect(user).approve(router.getAddress(), amountToMint);
 
     await expect(
-      router.connect(user).requestCrossChainSwap(await srcToken.getAddress(), amount, fee, DST_CHAIN_ID, recipientAddr),
+      router.connect(user).requestCrossChainSwap(await srcToken.getAddress(), await dstToken.getAddress(), amount, fee, DST_CHAIN_ID, recipientAddr),
     ).to.emit(router, "SwapRequested");
   });
 
@@ -88,7 +135,7 @@ describe("Router", function () {
     await srcToken.connect(user).approve(router.getAddress(), amountToMint);
 
     await expect(
-      router.connect(user).requestCrossChainSwap(await srcToken.getAddress(), amount, fee, DST_CHAIN_ID, recipientAddr),
+      router.connect(user).requestCrossChainSwap(await srcToken.getAddress(), await dstToken.getAddress(), amount, fee, DST_CHAIN_ID, recipientAddr),
     ).to.be.revertedWithCustomError(router, "FeeTooLow");
   });
 
@@ -102,7 +149,7 @@ describe("Router", function () {
 
     const tx = await router
       .connect(user)
-      .requestCrossChainSwap(await srcToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
+      .requestCrossChainSwap(await srcToken.getAddress(), await dstToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
 
     let receipt = await tx.wait(1);
     if (!receipt) {
@@ -150,7 +197,7 @@ describe("Router", function () {
 
     const tx = await router
       .connect(user)
-      .requestCrossChainSwap(await srcToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
+      .requestCrossChainSwap(await srcToken.getAddress(), await dstToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
 
     let receipt = await tx.wait(1);
     if (!receipt) {
@@ -192,7 +239,7 @@ describe("Router", function () {
 
     const tx = await router
       .connect(user)
-      .requestCrossChainSwap(await srcToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
+      .requestCrossChainSwap(await srcToken.getAddress(), await dstToken.getAddress(), amount, fee, DST_CHAIN_ID, recipient.address);
 
     let receipt = await tx.wait(1);
     if (!receipt) {
@@ -341,15 +388,13 @@ describe("Router", function () {
       .connect(user)
       .relayTokens(await dstToken.getAddress(), recipientAddr, amount, requestId, srcChainId);
     const receipt = await tx.wait();
-    const blockNumber = await ethers.provider.getBlock(receipt!.blockNumber);
-    const timestamp = blockNumber!.timestamp;
 
     if (!receipt) {
       throw new Error("transaction has not been mined");
     }
 
     const routerInterface = Router__factory.createInterface();
-    const [reqId, sourceChainId, , token, solver, recipient, , fulfilledAt] = extractSingleLog(
+    const [reqId, sourceChainId, dstChainId] = extractSingleLog(
       routerInterface,
       receipt,
       await router.getAddress(),
@@ -359,7 +404,7 @@ describe("Router", function () {
     expect((await router.getFulfilledTransfers()).includes(requestId)).to.be.equal(true);
     expect((await router.getFulfilledTransfers()).length).to.be.equal(1);
 
-    const swapRequestReceipt = await router.getReceipt(requestId);
+    const swapRequestReceipt = await router.getSwapRequestReceipt(requestId);
     // Check receipt values
     expect(swapRequestReceipt[0]).to.equal(requestId);
     expect(swapRequestReceipt[1]).to.equal(srcChainId);
@@ -369,16 +414,11 @@ describe("Router", function () {
     expect(swapRequestReceipt[5]).to.equal(userAddr);
     expect(swapRequestReceipt[6]).to.equal(recipientAddr);
     expect(swapRequestReceipt[7]).to.equal(amount);
-    expect(swapRequestReceipt[8]).to.equal(timestamp);
 
-    // Check receipt values compared to emitted event
+    // Check transaction receipt values compared to emitted event
     expect(reqId).to.equal(swapRequestReceipt[0]);
     expect(sourceChainId).to.equal(swapRequestReceipt[1]);
-    expect(token).to.equal(await dstToken.getAddress());
-    expect(solver).to.equal(userAddr);
-    expect(recipient).to.equal(recipientAddr);
-    expect(amount).to.equal(amount);
-    expect(fulfilledAt).to.equal(timestamp);
+    expect(dstChainId).to.equal(swapRequestReceipt[2]);
   });
 
   it("should return correct isFulfilled status", async () => {


### PR DESCRIPTION
This one is for discussion and approval if it's a desired feature.

It implements a one to many src token to dst token mapping for a single dst chain or distinct dst chain ids.

Currently, we assume a 1-1 mapping for tokens on src and dst chain id but there might be cases where there are e.g., multiple USDC tokens on Polygon that are 1-1 in price and amount with a single USDC token on Base and we want to map / support them for the single USDC on Base.

